### PR TITLE
Add modern color theme

### DIFF
--- a/components/Homescreen/TripPlanModal.js
+++ b/components/Homescreen/TripPlanModal.js
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { View, Text, Modal, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
+import theme from '../theme';
 import { Button, CheckBox } from 'react-native-elements';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
 
@@ -72,7 +73,7 @@ const styles = StyleSheet.create({
     },
     modalContainer: {
         width: '90%',
-        backgroundColor: 'white',
+        backgroundColor: theme.colors.card,
         borderRadius: 20,
         padding: 20,
         alignItems: 'center',
@@ -86,19 +87,19 @@ const styles = StyleSheet.create({
     datePickerButton: {
         marginBottom: 20,
         padding: 15,
-        backgroundColor: '#F2F2F7',
+        backgroundColor: theme.colors.background,
         borderRadius: 10,
         width: '100%',
     },
     datePickerText: {
         fontSize: 16,
-        color: '#333',
+        color: theme.colors.text,
         textAlign: 'center',
     },
     input: {
         width: '100%',
         padding: 15,
-        borderColor: '#ccc',
+        borderColor: theme.colors.border,
         borderWidth: 1,
         borderRadius: 10,
         marginBottom: 20,
@@ -114,10 +115,10 @@ const styles = StyleSheet.create({
     },
     checkboxText: {
         fontSize: 16,
-        color: '#333',
+        color: theme.colors.text,
     },
     validateButton: {
-        backgroundColor: '#34C759',
+        backgroundColor: theme.colors.primary,
         borderRadius: 10,
         paddingVertical: 12,
         marginTop: 20,

--- a/components/mobileNavbar.js
+++ b/components/mobileNavbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import theme from './theme';
 import { FontAwesome } from '@expo/vector-icons';
 import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
 
@@ -51,7 +52,7 @@ const styles = StyleSheet.create({
         width: '100%', // Réduire la largeur pour l'effet flottant
         bottom: 20, // Mettre un espace de 20px pour donner l'effet flottant
         height: 70,
-        backgroundColor: '#fff',
+        backgroundColor: theme.colors.card,
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 10 }, // Ombre plus prononcée pour l'effet de flottement
         shadowOpacity: 0.3, // Augmenter l'opacité de l'ombre
@@ -74,7 +75,7 @@ const styles = StyleSheet.create({
         padding: 5,
     },
     text: {
-        color: '#333',
+        color: theme.colors.text,
         fontSize: 12,
     },
     icon: {

--- a/components/theme.js
+++ b/components/theme.js
@@ -1,0 +1,12 @@
+const theme = {
+  colors: {
+    primary: '#6366F1', // indigo
+    background: '#F3F4F6',
+    card: '#FFFFFF',
+    text: '#111827',
+    border: '#E5E7EB',
+    accent: '#F472B6',
+  },
+};
+
+export default theme;

--- a/screens/AttractionsScreen.js
+++ b/screens/AttractionsScreen.js
@@ -11,6 +11,7 @@ import {
     ActivityIndicator,
     Image,
 } from 'react-native';
+import theme from '../components/theme';
 import { useSelector, useDispatch } from 'react-redux';
 import { setAttractions, setWaitTimes } from '../redux/actions/actions';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -115,18 +116,18 @@ const AttractionsScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: theme.colors.background,
     },
     headerTitle: {
         fontSize: 24,
         fontWeight: '700',
-        color: '#333333',
+        color: theme.colors.text,
         textAlign: 'center',
     },
     searchInput: {
         padding: 12,
         fontSize: 16,
-        borderColor: '#DDDDDD',
+        borderColor: theme.colors.border,
         borderWidth: 1,
         borderRadius: 8,
         marginHorizontal: 10,
@@ -138,7 +139,7 @@ const styles = StyleSheet.create({
     itemContainer: {
         flexDirection: 'row',
         padding: 15,
-        backgroundColor: '#F8F8F8',
+        backgroundColor: theme.colors.card,
         marginVertical: 5,
         marginHorizontal: 10,
         borderRadius: 10,
@@ -156,11 +157,11 @@ const styles = StyleSheet.create({
     itemName: {
         fontSize: 18,
         fontWeight: '600',
-        color: '#333333',
+        color: theme.colors.text,
     },
     itemWaitTime: {
         fontSize: 16,
-        color: '#555555',
+        color: theme.colors.accent,
         marginTop: 5,
     },
     loadingContainer: {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -11,6 +11,7 @@ import {
     ScrollView,
     Alert,
 } from 'react-native';
+import theme from '../components/theme';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -742,7 +743,7 @@ const HomeScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
     safeArea: {
         flex: 1,
-        backgroundColor: '#F5F5F5',
+        backgroundColor: theme.colors.background,
     },
     headerContainer: {
         width: '100%',
@@ -788,10 +789,10 @@ const styles = StyleSheet.create({
     content: {
         flex: 1,
         padding: 20,
-        backgroundColor: '#F5F5F5',
+        backgroundColor: theme.colors.background,
     },
     planTripButton: {
-        backgroundColor: '#3498DB',
+        backgroundColor: theme.colors.primary,
         borderRadius: 8,
         paddingVertical: 12,
         marginHorizontal: 20,
@@ -813,29 +814,29 @@ const styles = StyleSheet.create({
         shadowRadius: 4,
         elevation: 5,
         marginTop: -20,
-        backgroundColor: '#FFFFFF',
+        backgroundColor: theme.colors.card,
     },
     dateNavigator: {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: '#E9F7FE',
+        backgroundColor: theme.colors.card,
         paddingHorizontal: 15,
         paddingVertical: 10,
         borderRadius: 10,
         marginVertical: 15,
         borderWidth: 1,
-        borderColor: '#D4E6F1',
+        borderColor: theme.colors.border,
     },
     arrowIcon: {
         width: 30,
         height: 30,
-        tintColor: '#3498DB',
+        tintColor: theme.colors.primary,
     },
     currentDateText: {
         fontSize: 18,
         fontWeight: '500',
-        color: '#333333',
+        color: theme.colors.text,
         textAlign: 'center',
         flex: 1,
     },
@@ -848,14 +849,14 @@ const styles = StyleSheet.create({
         paddingVertical: 8,
         paddingHorizontal: 16,
         borderRadius: 20,
-        backgroundColor: '#E0E0E0',
+        backgroundColor: theme.colors.border,
     },
     selectedTimeSlotButton: {
-        backgroundColor: '#3498DB',
+        backgroundColor: theme.colors.primary,
     },
     timeSlotButtonText: {
         fontSize: 16,
-        color: '#555555',
+        color: theme.colors.text,
     },
     selectedTimeSlotButtonText: {
         color: '#FFFFFF',
@@ -865,7 +866,7 @@ const styles = StyleSheet.create({
         width: 60,
         height: 60,
         borderRadius: 30,
-        backgroundColor: '#3498DB',
+        backgroundColor: theme.colors.primary,
         justifyContent: 'center',
         alignItems: 'center',
         right: 20,
@@ -878,7 +879,7 @@ const styles = StyleSheet.create({
         tintColor: 'white',
     },
     modifyTripButton: {
-        backgroundColor: '#3498DB',
+        backgroundColor: theme.colors.primary,
         borderRadius: 8,
         paddingVertical: 12,
         marginHorizontal: 20,


### PR DESCRIPTION
## Summary
- add `theme.js` with modern palette
- use theme colors in `HomeScreen`, `AttractionsScreen`, `mobileNavbar`, and `TripPlanModal`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a10a0c483279efad8eeceb84f89